### PR TITLE
Add Shiny support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [ "develop" ]
     paths-ignore:
       - '**.md'
 
   pull_request:
-    branches: [ "develop" ]
     paths-ignore:
       - '**.md'
 
@@ -23,7 +21,7 @@ jobs:
         HADOLINT_RECURSIVE: "true"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: "Dockerfile*"
@@ -33,6 +31,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build the Docker image
       run: docker build . --file Dockerfile.ci --tag ci:$(date +%s)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta
@@ -48,14 +48,14 @@ jobs:
           #echo "github.refname: $github.ref_name"
         
       - name: Login to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
             registry: ghcr.io
             username: ${{github.actor}}
             password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Publish image to GHCR
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
             file: ./Dockerfile
             context: .

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -4,3 +4,5 @@ ignored:                                 # list of rules
   - DL3007
   # Pin versions in apt get install.
   - DL3008
+  # Need to see progress of wget
+  - DL3047

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,11 +60,11 @@ RUN mkdir /data \
 
 
 RUN rm -rf /srv/shiny-server/*
-COPY /app/ /srv/shiny-server/app
-COPY .Renviron.template /srv/shiny-server/app/.Renviron
+COPY /app/ /srv/shiny-server/
+COPY .Renviron.template /srv/shiny-server/.Renviron
 COPY shiny-customized.config /etc/shiny-server/shiny-server.conf
 
-WORKDIR /srv/shiny-server/app
+WORKDIR /srv/shiny-server/
 
 RUN chown -R shiny:shiny . && \
     chmod ug+x start-script.sh

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -60,11 +60,11 @@ RUN mkdir /data \
 
 
 RUN rm -rf /srv/shiny-server/*
-COPY /app/ /srv/shiny-server/app
-COPY .Renviron.template /srv/shiny-server/app/.Renviron
+COPY /app/ /srv/shiny-server/
+COPY .Renviron.template /srv/shiny-server/.Renviron
 COPY shiny-customized.config /etc/shiny-server/shiny-server.conf
 
-WORKDIR /srv/shiny-server/app
+WORKDIR /srv/shiny-server/
 
 RUN chown -R shiny:shiny . && \
     chmod ug+x start-script.sh

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -31,10 +31,11 @@ ENV PATH="/opt/ncbi-blast-2.13.0+/bin:${PATH}"
 RUN R -e "install.packages('remotes')" \
     && R -e "install.packages('BiocManager')" \
     && R -e "BiocManager::install('KEGGREST')" \
+    && R -e "remotes::install_version('rBLAST', repos = 'https://bioc.r-universe.dev', dependencies= T, version='1.5.0')" \
     && R -e "remotes::install_version('tidyverse', version = '2.0.0', dependencies= T)" \
     && R -e "remotes::install_version('arrow', version = '14.0.0', dependencies= T)" \
     && R -e "remotes::install_version('data.table', version = '1.14.8', dependencies= T)" \
-    && R -e "remotes::install_version('rBLAST', repos = 'https://mhahsler.r-universe.dev', dependencies= T, version='0.99.0')" \
+    #&& R -e "remotes::install_version('rBLAST', repos = 'https://mhahsler.r-universe.dev', dependencies= T, version='0.99.0')" \
     #&& R -e "remotes::install_github('mhahsler/rBLAST', dependencies= T)" \
     && R -e "remotes::install_version('leaflet', version = '2.1.2', dependencies= T)" \
     && R -e "remotes::install_version('sp', version = '1.6-1', dependencies= T)" \

--- a/shiny-customized.config
+++ b/shiny-customized.config
@@ -8,7 +8,7 @@ server {
   location / {
 
     # Host the directory of Shiny Apps stored in this directory
-    site_dir /srv/shiny-server/app;
+    site_dir /srv/shiny-server;
 
     # Log all Shiny output to files in this directory
     log_dir /var/log/shiny-server;


### PR DESCRIPTION
Changes to support the deployment as a shiny app. The shiny app files need to be copied directly under the path /srv/shiny-server/ .  Also bumped several versions.